### PR TITLE
Add sanitizeInput Jest tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "canvascreator",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.6.0"
+  }
+}

--- a/scripts/canvasCreatorUI.js
+++ b/scripts/canvasCreatorUI.js
@@ -2650,4 +2650,9 @@ fileInput.addEventListener("change", function () {
     }
     return text
   }
+
+  // Export for testing in Node environment
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports.sanitizeInput = sanitizeInput
+  }
   

--- a/tests/sanitizeInput.test.js
+++ b/tests/sanitizeInput.test.js
@@ -1,0 +1,15 @@
+const { sanitizeInput } = require('../scripts/canvasCreatorUI.js');
+
+describe('sanitizeInput', () => {
+  test('removes <script> tags', () => {
+    const input = 'Hello<script>alert("XSS")</script>World';
+    const result = sanitizeInput(input);
+    expect(result).toBe('HelloWorld');
+  });
+
+  test('keeps other HTML intact', () => {
+    const input = 'Hello <b>World</b>';
+    const result = sanitizeInput(input);
+    expect(result).toBe('Hello <b>World</b>');
+  });
+});


### PR DESCRIPTION
## Summary
- set up Jest test configuration
- export sanitizeInput for Node tests
- test sanitizeInput cleans script tags

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_685d774d1b08832ca5502e1021c23054