### PR TITLE
Install DOMPurify and update sanitizer

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "scripts": {
     "test": "jest"
   },
+  "dependencies": {
+    "dompurify": "^3.0.8"
+  },
   "devDependencies": {
     "jest": "^29.6.0"
   }

--- a/scripts/canvasCreatorUI.js
+++ b/scripts/canvasCreatorUI.js
@@ -1707,7 +1707,11 @@ const canvasData = {
     }
   }
 }
-  
+
+  // DOMPurify for sanitization
+  const createDOMPurify = require('dompurify')
+  const DOMPurify = createDOMPurify(window)
+
   // Sticky note variables
   let currentColor = defaultStyles.stickyNoteColor
   let selectedNote = null
@@ -2834,9 +2838,7 @@ fileInput.addEventListener("change", function () {
   
   // Function to sanitize text input
   function sanitizeInput(text) {
-    // You can use a library like DOMPurify for more robust sanitization
-    // For now, a simple example to remove script tags:
-    return text.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, "")
+    return DOMPurify.sanitize(text)
   }
   
   // Function to validate text input (limit length)

--- a/tests/sanitizeInput.test.js
+++ b/tests/sanitizeInput.test.js
@@ -1,3 +1,4 @@
+/** @jest-environment jsdom */
 const { sanitizeInput } = require('../scripts/canvasCreatorUI.js');
 
 describe('sanitizeInput', () => {
@@ -11,5 +12,11 @@ describe('sanitizeInput', () => {
     const input = 'Hello <b>World</b>';
     const result = sanitizeInput(input);
     expect(result).toBe('Hello <b>World</b>');
+  });
+
+  test('removes dangerous attributes', () => {
+    const input = '<img src="x" onerror="alert(1)">';
+    const result = sanitizeInput(input);
+    expect(result).toBe('<img src="x">');
   });
 });


### PR DESCRIPTION
## Summary
- install DOMPurify in `package.json`
- use DOMPurify in `sanitizeInput`
- cover new behaviour in tests

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_686005861c18832cb3d76a4db8d94e91