### PR TITLE
Add sticky note tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,12 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm install
+      - run: npm test

--- a/scripts/noteManager.js
+++ b/scripts/noteManager.js
@@ -1,0 +1,51 @@
+const { sanitizeInput } = require('./canvasCreatorUI.js');
+
+function createStickyNote(contentData, sectionId, text, position = { x: 0, y: 0 }, color = '#FFF399') {
+  const section = contentData.sections.find(s => s.sectionId === sectionId);
+  if (!section) {
+    throw new Error('Section not found');
+  }
+  const note = { content: sanitizeInput(text), position, size: contentData.stickyNoteSize || 80, color };
+  section.stickyNotes.push(note);
+  return note;
+}
+
+function editStickyNote(note, newContent) {
+  note.content = sanitizeInput(newContent);
+  return note;
+}
+
+function exportJSON(contentData) {
+  const exportData = {
+    templateId: contentData.templateId,
+    locale: contentData.locale,
+    metadata: contentData.metadata,
+    sections: contentData.sections.map(section => ({
+      sectionId: section.sectionId,
+      stickyNotes: section.stickyNotes.map(n => ({
+        content: n.content,
+        position: n.position,
+        size: n.size,
+        color: n.color,
+      }))
+    }))
+  };
+  return JSON.stringify(exportData, null, 2);
+}
+
+function importJSON(json) {
+  return JSON.parse(json);
+}
+
+function switchLocale(contentData, locale) {
+  contentData.locale = locale;
+}
+
+module.exports = {
+  createStickyNote,
+  editStickyNote,
+  exportJSON,
+  importJSON,
+  switchLocale,
+};
+

--- a/tests/localization.test.js
+++ b/tests/localization.test.js
@@ -1,0 +1,22 @@
+const { switchLocale } = require('../scripts/noteManager.js');
+
+const fs = require('fs');
+
+function loadLocalizedData(locale) {
+  const json = JSON.parse(fs.readFileSync('data/localizedData.json', 'utf8'));
+  return json[locale];
+}
+
+describe('localization and import/export', () => {
+  test('switch locale updates data', () => {
+    const content = { locale: 'en-US' };
+    switchLocale(content, 'de-DE');
+    expect(content.locale).toBe('de-DE');
+  });
+
+  test('localized data exists for en-US', () => {
+    const data = loadLocalizedData('en-US');
+    expect(data).toBeDefined();
+    expect(data.apiBusinessModelCanvas.title).toBeDefined();
+  });
+});

--- a/tests/stickyNotes.test.js
+++ b/tests/stickyNotes.test.js
@@ -1,0 +1,37 @@
+const { createStickyNote, editStickyNote, exportJSON, importJSON } = require('../scripts/noteManager.js');
+
+describe('sticky note operations', () => {
+  let contentData;
+
+  beforeEach(() => {
+    contentData = {
+      templateId: 'apiBusinessModelCanvas',
+      locale: 'en-US',
+      metadata: { source: 'test', license: 'MIT', authors: ['a'], website: 'example.com' },
+      stickyNoteSize: 80,
+      sections: [
+        { sectionId: 'sec1', stickyNotes: [] },
+      ],
+    };
+  });
+
+  test('create sticky note', () => {
+    const note = createStickyNote(contentData, 'sec1', 'hello', { x: 10, y: 20 });
+    expect(contentData.sections[0].stickyNotes.length).toBe(1);
+    expect(note.content).toBe('hello');
+  });
+
+  test('edit sticky note', () => {
+    const note = createStickyNote(contentData, 'sec1', 'hello');
+    editStickyNote(note, 'changed');
+    expect(note.content).toBe('changed');
+  });
+
+  test('export and import flow', () => {
+    createStickyNote(contentData, 'sec1', 'exported', { x: 1, y: 1 });
+    const json = exportJSON(contentData);
+    const imported = importJSON(json);
+    expect(imported.sections[0].stickyNotes[0].content).toBe('exported');
+    expect(imported.locale).toBe('en-US');
+  });
+});


### PR DESCRIPTION
## Summary
- add utility for sticky note data manipulation
- write tests for sticky note operations and localization
- run jest via GitHub Actions

## Testing
- `npm test` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6860073ceb4c832c87cdfda2537c7df8