### PR TITLE
Fix duplicated dependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,6 @@
   "dependencies": {
     "dompurify": "^3.0.8"
   },
-  "dependencies": {
-    "dompurify": "^3.0.8"
-  },
   "devDependencies": {
     "jest": "^29.6.0",
     "jest-environment-jsdom": "^29.6.0"


### PR DESCRIPTION
## Summary
- remove duplicate `dependencies` section from package.json to keep a single entry containing `dompurify`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6860ebc02b88832c8821695223ea4f69