### PR TITLE
Remove dompurify dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,7 @@
     "test": "jest",
     "build": "node scripts/build.js"
   },
-  "dependencies": {
-    "dompurify": "^3.0.8"
-  },
+  "dependencies": {},
   "devDependencies": {
     "jest": "^29.6.0",
     "jest-environment-jsdom": "^29.6.0"


### PR DESCRIPTION
## Summary
- remove `dompurify` from dependencies in `package.json`

npm install failed due to lack of network access, so `package-lock.json` could not be generated.

## Testing
- `npm install --ignore-scripts --no-audit --prefer-offline` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_686199fa25f8832cad3285336fbd90bc