### PR TITLE
Add tests for validateInput

### DIFF
--- a/tests/validateInput.test.js
+++ b/tests/validateInput.test.js
@@ -1,0 +1,16 @@
+const { validateInput } = require('../src/helpers.js');
+
+describe('validateInput', () => {
+  test('truncates strings longer than 200 characters', () => {
+    const longInput = 'a'.repeat(205);
+    const result = validateInput(longInput);
+    expect(result).toBe(longInput.substring(0, 200));
+    expect(result.length).toBe(200);
+  });
+
+  test('passes through short strings unchanged', () => {
+    const shortInput = 'Short text';
+    const result = validateInput(shortInput);
+    expect(result).toBe(shortInput);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for `validateInput` to ensure truncation of long strings and passthrough for short strings


------
https://chatgpt.com/codex/tasks/task_b_68619f08a714832caeffec3624aa7eb8