### PR TITLE
Add author and license info in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ dist/
 
 Both formats include the same API so your bundler can pick whichever it understands. CSS minification still works with `npm run minify-css`.
 
+The build also runs automatically when installing from git or publishing the package thanks to the `prepare` script in `package.json`.
+
 To use the library directly in a browser without a bundler, load the ESM file:
 
 ```html

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "test": "jest",
     "build": "rollup -c",
+    "prepare": "npm run build",
     "minify-css": "cleancss -o canvascreator.min.css styles/canvascreator.css",
     "export": "node scripts/export.js"
   },
@@ -21,5 +22,7 @@
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@rollup/plugin-json": "^6.0.0"
   },
-  "module": "dist/canvascreator.esm.js"
+  "module": "dist/canvascreator.esm.js",
+  "author": "Marjukka Niinioja (www.osaango.com)",
+  "license": "Apache-2.0"
 }


### PR DESCRIPTION
## Summary
- run build automatically via `prepare` script
- document prepare step in README
- specify Apache-2.0 license and author info in `package.json`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6887d5057bf4832c8f7a45b0243626b7