### PR TITLE
Fix CLI export availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,13 @@ Any framework that supports ES modules (React, Vue, etc.) can use the same API.
 
 You can also export canvases outside the browser using Node.js. The helper
 script `scripts/export.js` reads the canvas definitions and generates JSON,
-SVG, or PDF output. Execute it via the convenient npm script:
+SVG, or PDF output. Install the package and run the bundled CLI:
+
+```sh
+npx canvascreator-export --locale en-US --format svg --all --prefix My
+```
+
+If you've cloned this repository you can alternatively run:
 
 ```sh
 npm run export -- --locale en-US --format svg --all --prefix My

--- a/package.json
+++ b/package.json
@@ -26,7 +26,14 @@
   "module": "dist/canvascreator.esm.js",
   "author": "Marjukka Niinioja (www.osaango.com)",
   "license": "Apache-2.0",
+  "bin": {
+    "canvascreator-export": "scripts/export.js"
+  },
   "files": [
-    "dist"
+    "dist",
+    "scripts",
+    "src",
+    "data",
+    "img"
   ]
 }


### PR DESCRIPTION
## Summary
- publish export script and data with the npm package
- document the new `canvascreator-export` command

## Testing
- `npm install` *(fails: unable to access registry)*

------
https://chatgpt.com/codex/tasks/task_b_6888894f1fe4832cb24177a2160bbd3e