### PR TITLE
Fix export docs and add TypeScript types

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ Options:
 - `--import <file>` – load an existing JSON content file instead of creating
   placeholders
 
-Files are written to the current directory following the pattern
-`{prefix}_{canvasId}_{locale}.ext`.
+Files are written to an `export/` subdirectory following the pattern
+`export/{prefix}_{canvasId}_{locale}.ext`.
 
 ## How to Contribute
 Contributions are welcome, especially localization help, bug fixing, or contributing libraries in other languages or frameworks!

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,60 @@
+declare module "canvascreator" {
+  export interface DefaultStyles {
+    width: number;
+    height: number;
+    headerHeight: number;
+    footerHeight: number;
+    fontSize: number;
+    fontFamily: string;
+    backgroundColor: string;
+    borderColor: string;
+    fontColor: string;
+    contentFontColor: string;
+    highlightColor: string;
+    sectionColor: string;
+    padding: number;
+    cornerRadius: number;
+    circleRadius: number;
+    lineSize: number;
+    shadowColor: string;
+    stickyNoteSize: number;
+    stickyNoteSpacing: number;
+    stickyNoteCornerRadius: number;
+    maxLineWidth: number;
+    stickyNoteColor: string;
+    stickyNoteBorderColor: string;
+    defaultLocale: string;
+  }
+
+  export function createCanvas(
+    locale: string,
+    canvasId: string,
+    preserveContentData?: boolean
+  ): void;
+
+  export function loadCanvas(
+    locale: string,
+    canvasId: string,
+    preserveContentData?: boolean
+  ): void;
+
+  export function sanitizeInput(text: string): string;
+  export function validateInput(text: string): string;
+  export function distributeMissingPositions(
+    content: any,
+    canvasDef: any,
+    styles?: DefaultStyles
+  ): any;
+
+  export const defaultStyles: DefaultStyles;
+
+  const _default: {
+    createCanvas: typeof createCanvas;
+    loadCanvas: typeof loadCanvas;
+    sanitizeInput: typeof sanitizeInput;
+    validateInput: typeof validateInput;
+    distributeMissingPositions: typeof distributeMissingPositions;
+    defaultStyles: DefaultStyles;
+  };
+  export default _default;
+}

--- a/package.json
+++ b/package.json
@@ -29,11 +29,13 @@
   "bin": {
     "canvascreator-export": "scripts/export.js"
   },
+  "types": "index.d.ts",
   "files": [
     "dist",
     "scripts",
     "src",
     "data",
-    "img"
+    "img",
+    "index.d.ts"
   ]
 }

--- a/scripts/export.js
+++ b/scripts/export.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 if (typeof TextEncoder === "undefined") {
   global.TextEncoder = require("util").TextEncoder;
   global.TextDecoder = require("util").TextDecoder;


### PR DESCRIPTION
## Summary
- add node shebang to CLI script
- document export output directory
- provide TypeScript declaration file and hook it up in package.json

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68889073dbf8832c8e96393327cac728