### PR TITLE
Fix missing jsdom dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "pdfkit": "^0.17.1",
-        "svg-to-pdfkit": "^0.1.8"
+        "svg-to-pdfkit": "^0.1.8",
+        "jsdom": "^26.1.0"
       },
       "bin": {
         "canvascreator-export": "scripts/export.js"
@@ -4402,7 +4403,7 @@
       "version": "26.1.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
-      "dev": true,
+      "dev": false,
       "license": "MIT",
       "dependencies": {
         "cssstyle": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "pdfkit": "^0.17.1",
-    "svg-to-pdfkit": "^0.1.8"
+    "svg-to-pdfkit": "^0.1.8",
+    "jsdom": "^26.1.0"
   },
   "devDependencies": {
     "jest": "^30.0.5",


### PR DESCRIPTION
## Summary
- include `jsdom` in runtime dependencies so the export script works when installed from npm

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6888ac29bb9c832ca9684391e81a2d6e