### PR TITLE
Add fallback UI for browser bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,17 @@ Both formats include the same API so your bundler can pick whichever it understa
 
 The build also runs automatically when installing from git or publishing the package thanks to the `prepare` script in `package.json`.
 
-To use the library directly in a browser without a bundler, load the minified ESM file:
+To use the library directly in a browser without a bundler, import the minified
+ESM file using a relative path:
 
 ```html
-<script type="module" src="dist/canvascreator.esm.min.js"></script>
+<script type="module">
+  import { loadCanvas } from "./dist/canvascreator.esm.min.js";
+  loadCanvas("en-US", "apiBusinessModelCanvas");
+</script>
 ```
+
+**Note**: If those elements aren't present the library now inserts a minimal UI with locale and canvas selectors plus import/export buttons. You can still provide your own markup and just call `loadCanvas(locale, canvasId)` if you want to handle the UI yourself.
 
 During the build, `scripts/updateVersion.js` copies `index.html` and the
 necessary images into the `dist` folder. It also replaces the

--- a/src/main.js
+++ b/src/main.js
@@ -18,6 +18,58 @@ const defaultStyles = require('./defaultStyles');
 const canvasData = require("../data/canvasData.json");
 const localizedData = require("../data/localizedData.json");
 
+  // Ensure required UI elements exist, creating them when missing
+  function ensureUIExists() {
+    if (!document.getElementById("toolContainer")) {
+      const container = document.createElement("div");
+      container.id = "toolContainer";
+      container.innerHTML = `
+        <div id="localeSelector">
+          <label for="locale">Select Locale:</label>
+          <select id="locale"></select>
+        </div>
+        <div id="canvasSelector" style="display:none">
+          <label for="canvas">Select Canvas:</label>
+          <select id="canvas"></select>
+        </div>
+        <div id="canvasToolGroup">
+          <button id="metadataButton" class="canvas-tools">Edit Metadata</button>
+          <button id="importButton" class="canvas-tools">Import JSON</button>
+          <button id="exportButton" class="canvas-tools">Export JSON</button>
+          <button id="exportSVGButton" class="canvas-tools">Export SVGs</button>
+          <div id="colorPalette">
+            <button class="colorSwatch" style="background-color:#c0eb6a" data-color="#C0EB6A"></button>
+            <button class="colorSwatch" style="background-color:#dfddc5" data-color="#DFDDC5"></button>
+            <button class="colorSwatch" style="background-color:#ffafaf" data-color="#FFAFAF"></button>
+            <button class="colorSwatch" style="background-color:#7dc9e7" data-color="#7DC9E7"></button>
+            <button class="colorSwatch" style="background-color:#fff399" data-color="#FFF399"></button>
+          </div>
+        </div>
+        <div id="metadataForm" style="display:none">
+          <h2>Content Metadata</h2>
+          <label for="source">Source:</label>
+          <input type="text" id="source" name="source" /><br /><br />
+          <label for="license">License:</label>
+          <input type="text" id="license" name="license" /><br /><br />
+          <label for="authors">Authors:</label>
+          <input type="text" id="authors" name="authors" /><br /><br />
+          <label for="website">Website:</label>
+          <input type="text" id="website" name="website" /><br /><br />
+          <button id="saveMetadata">Save Metadata</button>
+        </div>`;
+      document.body.prepend(container);
+    }
+
+    if (!document.getElementById("canvasCreator")) {
+      const creator = document.createElement("div");
+      creator.id = "canvasCreator";
+      document.body.appendChild(creator);
+    }
+  }
+
+  // Create UI if missing
+  ensureUIExists();
+
   // No DOMPurify setup; sanitization is handled in helpers
 
   // Sticky note variables


### PR DESCRIPTION
## Summary
- add `ensureUIExists` helper that inserts selectors and buttons when missing
- document new auto-generated UI in README

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6888d41fd3a4832cad077f6da19f6a6d