### PR TITLE
Fix export JSON to use canvasId field

### DIFF
--- a/examples/Canvas_apiBusinessModelCanvas_en-US.json
+++ b/examples/Canvas_apiBusinessModelCanvas_en-US.json
@@ -1,5 +1,5 @@
 {
-  "templateId": "apiBusinessModelCanvas",
+  "canvasId": "apiBusinessModelCanvas",
   "metadata": {
     "source": "",
     "license": "",

--- a/scripts/export.js
+++ b/scripts/export.js
@@ -60,7 +60,7 @@ function buildContent(canvasData, canvasId, locale, addPlaceholder, imported) {
   }
   const canvasDef = canvasData[canvasId];
   const content = {
-    templateId: canvasId,
+    canvasId: canvasId,
     locale,
     stickyNoteSize: defaultStyles.stickyNoteSize,
     metadata: { source: '', license: '', authors: [], website: '' },
@@ -351,7 +351,7 @@ async function main() {
     const files = Array.isArray(args.import) ? args.import : [args.import];
     for (const file of files) {
       const obj = JSON.parse(fs.readFileSync(file, 'utf8'));
-      imports[obj.templateId] = obj;
+      imports[obj.canvasId] = obj;
     }
   }
   for (const id of canvasIds) {

--- a/scripts/noteManager.js
+++ b/scripts/noteManager.js
@@ -18,7 +18,7 @@ function editStickyNote(note, newContent) {
 
 function exportJSON(contentData) {
   const exportData = {
-    templateId: contentData.templateId,
+    canvasId: contentData.canvasId,
     locale: contentData.locale,
     metadata: contentData.metadata,
     sections: contentData.sections.map(section => ({

--- a/src/main.js
+++ b/src/main.js
@@ -23,6 +23,8 @@ const localizedData = require("../data/localizedData.json");
   // Sticky note variables
   let currentColor = defaultStyles.stickyNoteColor
   let selectedNote = null
+  let canvasId = null
+  let unsavedChanges = false
   
 
   
@@ -122,7 +124,7 @@ fileInput.addEventListener("change", function () {
       const importedData = JSON.parse(event.target.result)
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
       if (
-        !importedData.templateId ||
+        !importedData.canvasId ||
         !importedData.metadata ||
         !importedData.sections
       ) {
@@ -131,7 +133,7 @@ fileInput.addEventListener("change", function () {
       }
   
       // Save the imported values
-      canvasId = importedData.templateId
+      canvasId = importedData.canvasId
       contentData = importedData
       canvasDataForId = canvasData[canvasId]
 
@@ -198,7 +200,7 @@ fileInput.addEventListener("change", function () {
     // Only reset contentData if NOT importing
     if (!preserveContentData) {
       contentData = {
-        templateId: canvasId,
+        canvasId: canvasId,
         locale: locale,
         metadata: {
           source: "",
@@ -259,13 +261,13 @@ fileInput.addEventListener("change", function () {
   
       const locale = contentData.locale || defaultStyles.defaultLocale // Default to en-US if not provided
       // Use canvasId to access the correct localized data
-      const canvasId = contentData.templateId
+      const canvasId = contentData.canvasId
       const localizedCanvasData = localizedData[locale][canvasId]
   
       // Check if contentData is empty
       if (Object.keys(contentData).length === 0) {
         // Create a new contentData structure based on canvasData
-        contentData.templateId = canvasData.id
+        contentData.canvasId = canvasData.id
         contentData.locale = locale // Or any default locale you prefer
         contentData.metadata = {
           source: "",
@@ -580,7 +582,7 @@ fileInput.addEventListener("change", function () {
       const exportJSONButton = document.getElementById("exportButton")
       exportJSONButton.onclick = () => {
         const exportData = {
-          templateId: contentData.templateId,
+          canvasId: contentData.canvasId,
           locale: contentData.locale,
           metadata: {
             ...contentData.metadata,
@@ -601,7 +603,7 @@ fileInput.addEventListener("change", function () {
         const link = document.createElement("a");
         link.href =
           "data:application/json;charset=utf-8," + encodeURIComponent(jsonString);
-        const filename = `${contentData.metadata.source || "Canvas"}_${contentData.templateId}_${contentData.locale}.json`;
+        const filename = `${contentData.metadata.source || "Canvas"}_${contentData.canvasId}_${contentData.locale}.json`;
         link.download = filename;
         document.body.appendChild(link);
         link.click();
@@ -630,7 +632,7 @@ fileInput.addEventListener("change", function () {
         });
         const link = document.createElement("a");
         link.href = URL.createObjectURL(blob);
-        const filename = `${contentData.metadata.source || "Canvas"}_${contentData.templateId}_${contentData.locale}.svg`;
+        const filename = `${contentData.metadata.source || "Canvas"}_${contentData.canvasId}_${contentData.locale}.svg`;
         link.download = filename;
         document.body.appendChild(link);
         link.click();
@@ -781,8 +783,8 @@ fileInput.addEventListener("change", function () {
       }
   
       contentData.sections.forEach((contentSection) => {
-        // Find the corresponding section in canvasData using sectionId and templateId
-        const canvasId = contentData.templateId // Get the canvas ID from contentData
+        // Find the corresponding section in canvasData using sectionId and canvasId
+        const canvasId = contentData.canvasId // Get the canvas ID from contentData
         const canvasSection = canvasData[canvasId].sections.find(
           (section) => section.id === contentSection.sectionId,
         )

--- a/tests/stickyNotes.test.js
+++ b/tests/stickyNotes.test.js
@@ -5,7 +5,7 @@ describe('sticky note operations', () => {
 
   beforeEach(() => {
     contentData = {
-      templateId: 'apiBusinessModelCanvas',
+      canvasId: 'apiBusinessModelCanvas',
       locale: 'en-US',
       metadata: { source: 'test', license: 'MIT', authors: ['a'], website: 'example.com' },
       stickyNoteSize: 80,


### PR DESCRIPTION
## Summary
- switch content data from `templateId` to `canvasId`
- update export helpers and main app to output the new field
- adjust example JSON and tests for `canvasId`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6889abdf1d54832cadd73ea6bd58265e