### PR TITLE
Fix import bug by defining canvasId

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -23,6 +23,8 @@ const localizedData = require("../data/localizedData.json");
   // Sticky note variables
   let currentColor = defaultStyles.stickyNoteColor
   let selectedNote = null
+  // Track the currently selected canvas ID
+  let canvasId = null
   
 
   


### PR DESCRIPTION
## Summary
- define global `canvasId` variable so import routine can assign to it

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6889b37829e8832c849458c3d24cbf1c