### PR TITLE
Scope SVG removal to canvas container

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -241,11 +241,11 @@ fileInput.addEventListener("change", function () {
       } catch (error) {}
     }
   
-    let svg = d3.select("svg")
+    let svg = d3.select("#canvasCreator svg")
   
     //main
     const renderCanvas = (canvasData, contentData, localizedData) => {
-      d3.select("svg").remove()
+      d3.select("#canvasCreator svg").remove()
   
       const cellWidth = Math.floor(
         (defaultStyles.width -

--- a/tests/svgRemoval.test.js
+++ b/tests/svgRemoval.test.js
@@ -1,0 +1,15 @@
+describe('svg removal scoped to container', () => {
+  test('only removes svg inside #canvasCreator', () => {
+    document.body.innerHTML = `
+      <div id="canvasCreator"><svg id="target"></svg></div>
+      <svg id="other"></svg>
+    `;
+
+    // simulate the removal logic from src/main.js
+    const svgToRemove = document.querySelector('#canvasCreator svg');
+    if (svgToRemove) svgToRemove.remove();
+
+    expect(document.querySelector('#canvasCreator svg')).toBeNull();
+    expect(document.querySelector('#other')).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- scope initial SVG selection to `#canvasCreator`
- remove old SVG only from the canvas container
- test that only targeted SVGs are removed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6889bd9c0894832c8d91eb855dec3a82