### PR TITLE
Add initCanvasCreator and defer DOM listener setup

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,6 +123,9 @@
       }
     </script>
     <!-- load the ESM bundle -->
-    <script type="module" src="dist/canvascreator.esm.min.js?v=<%= version %>"></script>
+    <script type="module">
+      import { initCanvasCreator } from './dist/canvascreator.esm.min.js?v=<%= version %>';
+      initCanvasCreator();
+    </script>
   </body>
 </html>

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ const defaultStyles = require('./defaultStyles');
 
 exports.createCanvas = canvasCreator.loadCanvas;
 exports.loadCanvas = canvasCreator.loadCanvas;
+exports.initCanvasCreator = canvasCreator.initCanvasCreator;
 exports.sanitizeInput = helpers.sanitizeInput;
 exports.validateInput = helpers.validateInput;
 exports.distributeMissingPositions = helpers.distributeMissingPositions;
@@ -13,6 +14,7 @@ exports.defaultStyles = defaultStyles;
 module.exports = {
   createCanvas: exports.createCanvas,
   loadCanvas: exports.loadCanvas,
+  initCanvasCreator: exports.initCanvasCreator,
   sanitizeInput: exports.sanitizeInput,
   validateInput: exports.validateInput,
   distributeMissingPositions: exports.distributeMissingPositions,

--- a/tests/initCanvasCreator.test.js
+++ b/tests/initCanvasCreator.test.js
@@ -1,0 +1,22 @@
+describe('initCanvasCreator', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    document.body.innerHTML = '';
+  });
+
+  test('module can be required without DOM', () => {
+    expect(() => require('../src/main.js')).not.toThrow();
+  });
+
+  test('initialization attaches without throwing', () => {
+    document.body.innerHTML = `
+      <select id="locale"></select>
+      <div id="canvasSelector"><select id="canvas"></select></div>
+      <div id="canvasCreator"></div>
+      <button id="metadataButton"></button>
+      <button id="saveMetadata"></button>
+    `;
+    const { initCanvasCreator } = require('../src/main.js');
+    expect(() => initCanvasCreator()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- add `initCanvasCreator` to attach DOM events lazily
- export the initializer via `src/index.js`
- update index.html to call `initCanvasCreator`
- add unit test ensuring initialization occurs safely

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6889bfd3e028832cb8832dc879b35313