### PR TITLE
Add assetBase option and export initCanvasCreator

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The build also runs automatically when installing from git or publishing the pac
 To use the library directly in a browser without a bundler, load the minified ESM file:
 
 ```html
-<script type="module" src="dist/canvascreator.esm.min.js"></script>
+<script type="module" src="canvascreator.esm.min.js"></script>
 ```
 
 During the build, `scripts/updateVersion.js` copies `index.html` and the
@@ -176,7 +176,7 @@ The test suite also runs automatically in GitHub Actions for each push and pull 
 The stylesheet is referenced with a version query
 (`canvascreator.min.css?v=<version>`) so browsers load the latest minified CSS.
 When serving the JavaScript bundles directly in the browser, use
-`dist/canvascreator.esm.min.js?v=<version>` so you can bump the query string to
+`canvascreator.esm.min.js?v=<version>` so you can bump the query string to
 invalidate cached copies on release.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -96,17 +96,20 @@ JavaScript files.
 
 ## Using in Front-end Projects
 
-Import the functions directly from the package in any bundler-based setup. For example with [Astro](https://astro.build/):
+Import the functions directly from the package in any bundler-based setup. For example with [Astro](https://astro.build/). Make sure [D3.js](https://d3js.org/) is loaded separately and copy `canvascreator.min.css` and the `img` directory from the package to your public folder.
 
 ```astro
 ---
-import { loadCanvas } from "canvascreator";
+import CanvasCreator from "canvascreator";
 ---
-<div id="canvas"></div>
+<div id="canvasCreator"></div>
 <script type="module">
-  loadCanvas("en-US", "apiBusinessModelCanvas");
+  CanvasCreator.initCanvasCreator({ assetBase: "/" });
+  CanvasCreator.loadCanvas("en-US", "apiBusinessModelCanvas");
 </script>
 ```
+
+The optional `assetBase` setting tells the library where to load `img` and CSS files from. It defaults to an empty string which points to the site root.
 
 Any framework that supports ES modules (React, Vue, etc.) can use the same API.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -38,6 +38,17 @@ declare module "canvascreator" {
     preserveContentData?: boolean
   ): void;
 
+  export interface InitOptions {
+    localeElement?: HTMLElement | null;
+    canvasElement?: HTMLElement | null;
+    canvasSelectorElement?: HTMLElement | null;
+    canvasCreatorElement?: HTMLElement | null;
+    toolsSelector?: string;
+    assetBase?: string;
+  }
+
+  export function initCanvasCreator(options?: InitOptions): void;
+
   export function sanitizeInput(text: string): string;
   export function validateInput(text: string): string;
   export function distributeMissingPositions(
@@ -51,6 +62,7 @@ declare module "canvascreator" {
   const _default: {
     createCanvas: typeof createCanvas;
     loadCanvas: typeof loadCanvas;
+    initCanvasCreator: typeof initCanvasCreator;
     sanitizeInput: typeof sanitizeInput;
     validateInput: typeof validateInput;
     distributeMissingPositions: typeof distributeMissingPositions;

--- a/index.html
+++ b/index.html
@@ -3,18 +3,18 @@
   <head>
     <title>APIOps Cycles - Canvas Creator</title>
     <script src="https://d3js.org/d3.v7.min.js"></script>
-    <link rel="stylesheet" href="/canvascreator.min.css?v=<%= version %>">
+    <link rel="stylesheet" href="<%= assetBase %>/canvascreator.min.css?v=<%= version %>">
     <link
       rel="icon"
       type="image/png"
-      href="/img/apiops-cycles-logo-2025-32.png"
+      href="<%= assetBase %>/img/apiops-cycles-logo-2025-32.png"
     />
   </head>
   <body>
     <span style="font-size: 30px; cursor: pointer" onclick="openNav()">&#9776;</span>
     <div id="toolContainer">
       <img
-        src="/img/apiops-cycles-logo2025-blue.svg"
+        src="<%= assetBase %>/img/apiops-cycles-logo2025-blue.svg"
         width="100px"
         height="100px"
       />
@@ -124,8 +124,8 @@
     </script>
     <!-- load the ESM bundle -->
     <script type="module">
-      import CanvasCreator from './dist/canvascreator.esm.min.js?v=<%= version %>';
-      CanvasCreator.initCanvasCreator();
+      import CanvasCreator from '<%= assetBase %>/dist/canvascreator.esm.min.js?v=<%= version %>';
+      CanvasCreator.initCanvasCreator({ assetBase: '<%= assetBase %>' });
     </script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@
     </script>
     <!-- load the ESM bundle -->
     <script type="module">
-      import CanvasCreator from '<%= assetBase %>/dist/canvascreator.esm.min.js?v=<%= version %>';
+      import CanvasCreator from '<%= assetBase %>/canvascreator.esm.min.js?v=<%= version %>';
       CanvasCreator.initCanvasCreator({ assetBase: '<%= assetBase %>' });
     </script>
   </body>

--- a/scripts/updateVersion.js
+++ b/scripts/updateVersion.js
@@ -3,21 +3,16 @@ const path = require('path');
 
 const pkg = require('../package.json');
 const version = pkg.version;
+const assetBase = process.env.ASSET_BASE || '.';
 
 // Read the source template index.html
 const src = path.join(__dirname, '..', 'index.html');
 let contents = fs.readFileSync(src, 'utf8');
 
 // Replace EJS-style placeholders with actual version number
-contents = contents.replace(/<%=\s*version\s*%>/g, version);
-
-// Adjust asset paths for the dist folder
 contents = contents
-  .replace(/href="\/canvascreator.min.css\?v=[^"]+"/, `href="canvascreator.min.css?v=${version}"`)
-  .replace(/src="dist\/canvascreator.esm.min.js\?v=[^"]+"/, `src="./canvascreator.esm.min.js?v=${version}"`)
-  .replace(/(["'])\.\/dist\/canvascreator\.esm\.min\.js/g, `$1./canvascreator.esm.min.js`)
-  .replace(/src="\/img\//g, 'src="img/')
-  .replace(/href="\/img\//g, 'href="img/');
+  .replace(/<%=\s*version\s*%>/g, version)
+  .replace(/<%=\s*assetBase\s*%>/g, assetBase);
 
 // Write the processed file into dist so the original stays untouched
 const outDir = path.join(__dirname, '..', 'dist');

--- a/src/index.js
+++ b/src/index.js
@@ -20,3 +20,4 @@ module.exports = {
   distributeMissingPositions: exports.distributeMissingPositions,
   defaultStyles: exports.defaultStyles,
 };
+exports.default = module.exports;

--- a/src/main.js
+++ b/src/main.js
@@ -14,6 +14,9 @@ const {
 } = require('./helpers');
 const defaultStyles = require('./defaultStyles');
 
+// Base path for images and CSS, updated by initCanvasCreator
+let assetBase = '';
+
 //load canvas layouts and localizations from json data
 const canvasData = require("../data/canvasData.json");
 const localizedData = require("../data/localizedData.json");
@@ -86,8 +89,10 @@ function initCanvasCreator({
   canvasSelectorElement,
   canvasCreatorElement,
   toolsSelector = '.canvas-tools',
-  assetBase = '',
+  assetBase: assetBaseParam = '',
 } = {}) {
+  // Expose assetBase to other functions
+  assetBase = assetBaseParam;
   const localeSel =
     localeElement || document.getElementById('locale')
   const canvasSel =

--- a/src/main.js
+++ b/src/main.js
@@ -86,6 +86,7 @@ function initCanvasCreator({
   canvasSelectorElement,
   canvasCreatorElement,
   toolsSelector = '.canvas-tools',
+  assetBase = '',
 } = {}) {
   const localeSel =
     localeElement || document.getElementById('locale')
@@ -405,7 +406,7 @@ fileInput.addEventListener("change", function () {
         .attr("height", defaultStyles.height)
         .style("background-color", defaultStyles.backgroundColor)
   
-      const logoUrl = "/img/apiops-cycles-logo2025-blue.svg"
+      const logoUrl = `${assetBase}/img/apiops-cycles-logo2025-blue.svg`
   
       fetchAPIOpsLogo(
         logoUrl,


### PR DESCRIPTION
## Summary
- support `assetBase` in `initCanvasCreator`
- expose init function in module exports
- generate demo with configurable asset location
- update TypeScript types and docs

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6889e3649458832cbf6cce42602aed24