### PR TITLE
Use external data package for canvas templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,9 @@ Options:
 - `--prefix <name>` – prefix for generated filenames (default `Canvas`)
 - `--all` – export every canvas from the `apiops-cycles-method-data` package
 - `--canvas <id>` – export a single canvas by id
-- `--import <file>` – load an existing JSON content file instead of creating
-  placeholders
+- `--import <file>` – load an existing JSON content file instead of creating placeholders
+- `--outdir <folder>     output directory for exported files (default export)`
+- `--help`
 
 PNG output requires the optional `canvas` package (v3). Install it with `npm install canvas@^3`.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -66,9 +66,6 @@ declare module "canvascreator" {
     sanitizeInput: typeof sanitizeInput;
     validateInput: typeof validateInput;
     distributeMissingPositions: typeof distributeMissingPositions;
-    defaultStyles: DefaultStyles;
-    ApiOpsCyclesMethodDataCanvasData: typeof import("/apiops-cycles-method-data/canvasData.json");
-    ApiOpsCyclesMethodDataLocalizedData: typeof import("/apiops-cycles-method-data/localizedData.json");
-  };
+    defaultStyles: DefaultStyles;  };
   export default _default;
 }

--- a/scripts/updateVersion.js
+++ b/scripts/updateVersion.js
@@ -38,7 +38,7 @@ for (const file of fs.readdirSync(imgDir)) {
   fs.copyFileSync(path.join(imgDir, file), path.join(imgDestDir, file));
 }
 
-// Copy canvasData.json and localizedData.json from apiops-cycles-method-data
+// Verify apiops-cycles-method-data exists and has canvas data
 const apiopsCyclesMethodDataDir = path.join(__dirname, '..', 'node_modules', 'apiops-cycles-method-data');
 if (!fs.existsSync(apiopsCyclesMethodDataDir)) {
   console.error('apiops-cycles-method-data not found. Please run npm install.');
@@ -48,13 +48,3 @@ if (!fs.existsSync(path.join(apiopsCyclesMethodDataDir, 'src', 'data', 'canvas')
   console.error('Canvas data files not found in apiops-cycles-method-data. Please check the package.');
   process.exit(1);
 }
-if (!fs.existsSync(path.join(outDir, 'apiops-cycles-method-data'))) {
-  fs.mkdirSync(path.join(outDir, 'apiops-cycles-method-data'), { recursive: true });
-}
-const canvasDataSrc = path.join(__dirname, '..', 'node_modules', 'apiops-cycles-method-data', 'src', 'data', 'canvas', 'canvasData.json');
-const localizedDataSrc = path.join(__dirname, '..', 'node_modules', 'apiops-cycles-method-data', 'src', 'data', 'canvas', 'localizedData.json');
-const canvasDataDest = path.join(outDir, 'apiops-cycles-method-data', 'canvasData.json');
-const localizedDataDest = path.join(outDir, 'apiops-cycles-method-data', 'localizedData.json');
-fs.copyFileSync(canvasDataSrc, canvasDataDest);
-fs.copyFileSync(localizedDataSrc, localizedDataDest);
-console.log('Copied canvasData.json and localizedData.json to dist directory');

--- a/src/index.js
+++ b/src/index.js
@@ -9,8 +9,6 @@ exports.sanitizeInput = helpers.sanitizeInput;
 exports.validateInput = helpers.validateInput;
 exports.distributeMissingPositions = helpers.distributeMissingPositions;
 exports.defaultStyles = defaultStyles;
-exports.ApiOpsCyclesMethodDataCanvasData = require('apiops-cycles-method-data/canvasData.json');
-exports.ApiOpsCyclesMethodDataLocalizedData = require('apiops-cycles-method-data/localizedData.json');
 
 // default export for CommonJS consumers
 module.exports = {
@@ -21,7 +19,5 @@ module.exports = {
   validateInput: exports.validateInput,
   distributeMissingPositions: exports.distributeMissingPositions,
   defaultStyles: exports.defaultStyles,
-  ApiOpsCyclesMethodDataCanvasData: exports.ApiOpsCyclesMethodDataCanvasData,
-  ApiOpsCyclesMethodDataLocalizedData: exports.ApiOpsCyclesMethodDataLocalizedData
 };
 exports.default = module.exports;

--- a/src/main.js
+++ b/src/main.js
@@ -18,7 +18,8 @@ const defaultStyles = require('./defaultStyles');
 let assetBase = '';
 
 // Load canvas layouts and localizations from the data package
-const { canvasData, localizedData } = require('apiops-cycles-method-data');
+const canvasData = require('../node_modules/apiops-cycles-method-data/src/data/canvas/canvasData.json');
+const localizedData = require('../node_modules/apiops-cycles-method-data/src/data/canvas/localizedData.json');
 
   // No DOMPurify setup; sanitization is handled in helpers
 

--- a/tests/export.test.js
+++ b/tests/export.test.js
@@ -1,6 +1,7 @@
 const { buildContent, buildFileName, renderSVG, writePNG } = require('../scripts/export.js');
 const { exportJSON } = require('../scripts/noteManager.js');
-const { canvasData, localizedData } = require('apiops-cycles-method-data');
+const canvasData = require('apiops-cycles-method-data/canvasData.json');
+const localizedData = require('apiops-cycles-method-data/localizedData.json');
 
 describe('export helpers', () => {
   test('buildFileName applies prefix', () => {

--- a/tests/localization.test.js
+++ b/tests/localization.test.js
@@ -1,6 +1,6 @@
 const { switchLocale } = require('../scripts/noteManager.js');
 
-const { localizedData } = require('apiops-cycles-method-data');
+const localizedData = require('apiops-cycles-method-data/localizedData.json');
 
 function loadLocalizedData(locale) {
   return localizedData[locale];


### PR DESCRIPTION
## Summary
- load canvas and localization data from `apiops-cycles-method-data`
- drop in-repo JSON data files
- reference new data package in CLI, docs, and tests
- mark data package JSON imports as external in Rollup build

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/apiops-cycles-method-data)*
- `npm test` *(fails: Cannot find module 'apiops-cycles-method-data')*


------
https://chatgpt.com/codex/tasks/task_b_689251b1f4dc832ca4b70c8ce0aff638