### PR TITLE
Support locale and canvas URL parameters

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -37,9 +37,10 @@ let unsavedChanges = false
 
 function getLocaleKey(locale) {
   if (!locale) return defaultStyles.defaultLocale
-  if (localizedData[locale]) return locale
-  const base = locale.split('-')[0]
-  return localizedData[base] ? base : locale
+  const lower = locale.toLowerCase()
+  if (localizedData[lower]) return lower
+  const base = lower.split('-')[0]
+  return localizedData[base] ? base : lower
 }
 
 

--- a/src/main.js
+++ b/src/main.js
@@ -201,6 +201,36 @@ function initCanvasCreator({
   // Initialize the locale selector
   populateLocaleSelector(localeSel)
 
+  // Parse locale and canvas from URL parameters securely
+  const params = new URLSearchParams(window.location.search)
+  let urlLocale = params.get('locale') || ''
+  let urlCanvas = params.get('canvas') || ''
+  urlLocale = validateInput(sanitizeInput(urlLocale))
+  urlCanvas = validateInput(sanitizeInput(urlCanvas))
+
+  if (urlLocale && localizedData[getLocaleKey(urlLocale)]) {
+    const normalizedLocale = getLocaleKey(urlLocale)
+    localeSel.value = normalizedLocale
+    populateCanvasSelector(normalizedLocale, canvasSel)
+    if (canvasSelectorContainer) {
+      canvasSelectorContainer.style.display = 'block'
+    }
+
+    if (
+      urlCanvas &&
+      localizedData[normalizedLocale] &&
+      localizedData[normalizedLocale][urlCanvas]
+    ) {
+      canvasSel.value = urlCanvas
+      loadCanvas(normalizedLocale, urlCanvas)
+      if (canvasCreator) {
+        canvasCreator.style.display = 'flex'
+      }
+      currentLocale = normalizedLocale
+      currentCanvas = urlCanvas
+    }
+  }
+
   // Before unload warning
   window.addEventListener('beforeunload', checkForUnsavedChanges)
 

--- a/tests/linkParameters.test.js
+++ b/tests/linkParameters.test.js
@@ -1,0 +1,71 @@
+const chainStub = new Proxy(
+  function () {},
+  {
+    get: (target, prop) => {
+      if (prop === 'node') {
+        return () => ({ getComputedTextLength: () => 0 })
+      }
+      return chainStub
+    },
+    apply: () => chainStub,
+  }
+)
+
+describe('URL parameter handling', () => {
+  beforeEach(() => {
+    jest.resetModules()
+    document.body.innerHTML = ''
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, text: () => Promise.resolve('') })
+    )
+    global.d3 = { select: () => chainStub, drag: () => chainStub }
+  })
+
+  test('valid locale and canvas are preselected', () => {
+    document.body.innerHTML = `
+      <select id="locale"></select>
+      <div id="canvasSelector" style="display:none"><select id="canvas"></select></div>
+      <div id="canvasCreator" style="display:none"></div>
+      <button id="metadataButton"></button>
+      <button id="saveMetadata"></button>
+      <button id="exportButton"></button>
+      <button id="exportSVGButton"></button>
+      <button id="exportPNGButton"></button>
+      <button id="importButton"></button>
+    `
+    window.history.pushState(
+      {},
+      '',
+      '?locale=en&canvas=apiBusinessModelCanvas'
+    )
+    const { initCanvasCreator } = require('../src/main.js')
+    initCanvasCreator()
+    expect(document.getElementById('locale').value).toBe('en')
+    expect(document.getElementById('canvas').value).toBe(
+      'apiBusinessModelCanvas'
+    )
+  })
+
+  test('malicious parameters are sanitized', () => {
+    document.body.innerHTML = `
+      <select id="locale"></select>
+      <div id="canvasSelector" style="display:none"><select id="canvas"></select></div>
+      <div id="canvasCreator" style="display:none"></div>
+      <button id="metadataButton"></button>
+      <button id="saveMetadata"></button>
+      <button id="exportButton"></button>
+      <button id="exportSVGButton"></button>
+      <button id="exportPNGButton"></button>
+      <button id="importButton"></button>
+    `
+    window.history.pushState(
+      {},
+      '',
+      '?locale=<script>alert(1)</script>&canvas=<img src=x onerror=alert(1)>'
+    )
+    const { initCanvasCreator } = require('../src/main.js')
+    initCanvasCreator()
+    expect(document.getElementById('locale').value).toBe('')
+    expect(document.getElementById('canvas').value).toBe('')
+  })
+})

--- a/tests/linkParameters.test.js
+++ b/tests/linkParameters.test.js
@@ -46,6 +46,31 @@ describe('URL parameter handling', () => {
     )
   })
 
+  test('locale parameter is case-insensitive and supports region variants', () => {
+    document.body.innerHTML = `
+      <select id="locale"></select>
+      <div id="canvasSelector" style="display:none"><select id="canvas"></select></div>
+      <div id="canvasCreator" style="display:none"></div>
+      <button id="metadataButton"></button>
+      <button id="saveMetadata"></button>
+      <button id="exportButton"></button>
+      <button id="exportSVGButton"></button>
+      <button id="exportPNGButton"></button>
+      <button id="importButton"></button>
+    `
+    window.history.pushState(
+      {},
+      '',
+      '?locale=FI-fi&canvas=apiBusinessModelCanvas',
+    )
+    const { initCanvasCreator } = require('../src/main.js')
+    initCanvasCreator()
+    expect(document.getElementById('locale').value).toBe('fi')
+    expect(document.getElementById('canvas').value).toBe(
+      'apiBusinessModelCanvas',
+    )
+  })
+
   test('malicious parameters are sanitized', () => {
     document.body.innerHTML = `
       <select id="locale"></select>


### PR DESCRIPTION
## Summary
- Allow pre-selecting locale and canvas via URL parameters
- Validate and sanitize query values before loading content
- Add tests for safe URL parameter handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689c18f9c0b4832cae33f6d7f811d1ea