### PR TITLE
Add canvas-import-json-authoring skill and bump apiops-cycles-method-data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "apiops-cycles-method-data": "^3.0.1",
+        "apiops-cycles-method-data": "^3.1.3",
         "jsdom": "^26.1.0",
         "pdfkit": "^0.17.1",
         "svg-to-pdfkit": "^0.1.8"
@@ -98,7 +98,6 @@
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -648,7 +647,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -671,7 +669,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2368,9 +2365,9 @@
       }
     },
     "node_modules/apiops-cycles-method-data": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/apiops-cycles-method-data/-/apiops-cycles-method-data-3.0.2.tgz",
-      "integrity": "sha512-JrHQ1OqR92QjA7KGAUeDdZ99B0m+J6wxVO1LpSXSBxxHJfZzLbHCATWPVMk08XMwwuBlraYWYBpXuef7J5/onw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/apiops-cycles-method-data/-/apiops-cycles-method-data-3.1.3.tgz",
+      "integrity": "sha512-AIuLd+H1g7OAk6dGo0N4xbnmshGybyQTtnQuqj90I5MFH1IYfZQBZmxWJseU0MMEzkyUNm3piL35A+gtG4cWZw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=22"
@@ -2589,7 +2586,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -2685,6 +2681,21 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvas": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-3.2.1.tgz",
+      "integrity": "sha512-ej1sPFR5+0YWtaVp6S1N1FVz69TQCqmrkGeRvQxZeAB1nAIcjNTHVwrZtYtWFFBmQsF40/uDLehsW5KuYC99mg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^7.0.0",
+        "prebuild-install": "^7.1.3"
+      },
+      "engines": {
+        "node": "^18.12.0 || >= 20.9.0"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -4597,7 +4608,6 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -5194,7 +5204,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5462,7 +5471,6 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "export": "node scripts/export.js"
   },
   "dependencies": {
-    "apiops-cycles-method-data": "^3.0.1",
+    "apiops-cycles-method-data": "^3.1.3",
     "jsdom": "^26.1.0",
     "pdfkit": "^0.17.1",
     "svg-to-pdfkit": "^0.1.8"

--- a/skills/canvas-import-json-authoring/SKILL.md
+++ b/skills/canvas-import-json-authoring/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: canvas-import-json-authoring
+description: Create or review importable CanvasCreator JSON files using schema-first validation, template-specific section coverage, locale-aware section descriptions, and APIOps metadata defaults. Use when generating new filled canvas examples, converting raw notes into import JSON, or validating existing import files before import/export.
+---
+
+# Canvas Import JSON Authoring
+
+Create import JSON in two passes: (1) schema validity, (2) content quality.
+
+## Workflow
+
+1. Choose `templateId` and `locale`.
+2. Validate JSON shape against `references/import-export-template.schema.json`.
+3. Validate section IDs against `node_modules/apiops-cycles-method-data/src/data/canvas/canvasData.json`.
+4. Generate sticky-note content from section `description` in `node_modules/apiops-cycles-method-data/src/data/canvas/localizedData.json` for the same locale + template.
+5. Apply metadata and color conventions.
+6. Return a descriptively named JSON file.
+
+## Required authoring rules
+
+- Include `templateId`, `metadata`, and `sections`.
+- Use every section in the selected template; do not add unknown sections.
+- Keep `stickyNotes` present for every section.
+- Omit sticky-note `position` unless explicit coordinates are requested (auto-layout handles placement).
+- Default sticky-note `size` to `80`; only reduce when needed to prevent overflow.
+
+## Metadata defaults
+
+For APIOps Cycles examples:
+
+- `source`: `APIOps Cycles method`
+- `license`: `CC-BY-SA 4.0`
+- `website`: `www.apiopscycles.com`
+- `authors`: content author(s)
+- `date`: ISO-8601 creation timestamp
+
+## Content and colors
+
+- Write concise notes that directly answer each section description.
+- Keep language aligned with selected locale.
+
+Default theme intent:
+
+- Tasks/journey/actions: blue
+- Benefits/positive outcomes: green
+- Risks/negative outcomes: pink
+- Neutral/supporting items: yellow
+
+## Filenames
+
+Use `<usecase>_<templateId>_<locale>.json`.
+
+Example: `example_apiBusinessModelCanvas_en.json`.
+
+## Validation commands
+
+Use `references/canvas-json-checks.md` for:
+
+- template + section lookups,
+- schema validation,
+- section coverage validation,
+- optional position-field checks.

--- a/skills/canvas-import-json-authoring/references/canvas-json-checks.md
+++ b/skills/canvas-import-json-authoring/references/canvas-json-checks.md
@@ -1,0 +1,57 @@
+# Canvas JSON checks and lookups
+
+Use these commands to build and validate importable canvas JSON.
+
+## 1) List valid template IDs
+
+```bash
+jq -r 'keys[]' node_modules/apiops-cycles-method-data/src/data/canvas/canvasData.json
+```
+
+## 2) List required section IDs for one template
+
+```bash
+TEMPLATE_ID="apiBusinessModelCanvas"
+jq -r --arg t "$TEMPLATE_ID" '.[$t].sections[].id' node_modules/apiops-cycles-method-data/src/data/canvas/canvasData.json
+```
+
+## 3) Read locale-specific section descriptions used to guide sticky-note content
+
+```bash
+LOCALE="en"
+TEMPLATE_ID="apiBusinessModelCanvas"
+jq -r --arg l "$LOCALE" --arg t "$TEMPLATE_ID" '.[$l][$t].sections | to_entries[] | "\(.key): \(.value.description)"' node_modules/apiops-cycles-method-data/src/data/canvas/localizedData.json
+```
+
+## 4) Validate JSON shape with schema
+
+Schema file:
+
+- `skills/canvas-import-json-authoring/references/import-export-template.schema.json`
+
+Validation command:
+
+```bash
+FILE="examples/Canvas_apiBusinessModelCanvas_en.json"
+npx --yes ajv-cli validate -s skills/canvas-import-json-authoring/references/import-export-template.schema.json -d "$FILE" --spec=draft2020
+```
+
+## 5) Verify generated JSON uses template sections only (and in expected order)
+
+```bash
+FILE="examples/Canvas_apiBusinessModelCanvas_en.json"
+jq -r '.sections[].sectionId' "$FILE" > /tmp/actual_sections.txt
+jq -r --arg t "$(jq -r '.templateId' "$FILE")" '.[$t].sections[].id' node_modules/apiops-cycles-method-data/src/data/canvas/canvasData.json > /tmp/expected_sections.txt
+diff -u /tmp/expected_sections.txt /tmp/actual_sections.txt
+```
+
+No diff means section coverage/order matches template.
+
+## 6) Verify positions are omitted (when auto-layout is desired)
+
+```bash
+FILE="path/to/generated.json"
+jq '.sections[].stickyNotes[] | has("position")' "$FILE"
+```
+
+All values should be `false` when positions are intentionally omitted.

--- a/skills/canvas-import-json-authoring/references/import-export-template.schema.json
+++ b/skills/canvas-import-json-authoring/references/import-export-template.schema.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://canvascreator.local/schemas/import-export-template.schema.json",
+  "title": "CanvasCreator import/export template",
+  "type": "object",
+  "required": ["templateId", "metadata", "sections"],
+  "additionalProperties": false,
+  "properties": {
+    "templateId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "metadata": {
+      "type": "object",
+      "required": ["source", "license", "authors", "website", "date"],
+      "additionalProperties": true,
+      "properties": {
+        "source": { "type": "string" },
+        "license": { "type": "string" },
+        "authors": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "website": { "type": "string" },
+        "date": { "type": "string" }
+      }
+    },
+    "sections": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["sectionId", "stickyNotes"],
+        "additionalProperties": false,
+        "properties": {
+          "sectionId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "stickyNotes": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["content", "size", "color"],
+              "additionalProperties": false,
+              "properties": {
+                "content": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "size": {
+                  "type": "number",
+                  "minimum": 20,
+                  "maximum": 120
+                },
+                "color": {
+                  "type": "string",
+                  "pattern": "^#([0-9A-Fa-f]{6})$"
+                },
+                "position": {
+                  "type": "object",
+                  "required": ["x", "y"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "x": { "type": "number" },
+                    "y": { "type": "number" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Motivation

- Provide a reusable authoring workflow and validation helpers for creating importable CanvasCreator JSON files. 
- Ensure templates and localized section descriptions are aligned with the APIOps Cycles data package.
- Keep dependency on `apiops-cycles-method-data` up to date to pull in template/localization fixes.

### Description

- Added a new skill `skills/canvas-import-json-authoring` with `SKILL.md` describing authoring rules, metadata defaults, color conventions and filename conventions. 
- Added reference utilities `references/canvas-json-checks.md` with `jq` and `ajv-cli` commands for listing templates, validating sections and schema validation. 
- Added `references/import-export-template.schema.json` JSON Schema to validate import/export template files. 
- Bumped dependency `apiops-cycles-method-data` from `^3.0.1` to `^3.1.3` in `package.json` and updated `package-lock.json`, which also includes an optional `canvas` entry and related lockfile updates.

### Testing

- Ran `npm run build` to exercise the build pipeline and asset generation, and the build completed successfully. 
- Ran `npm test` (Jest) and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b65a6bebe4832cb091cae866aa577e)